### PR TITLE
ApplicationCommandHandler: Handle null return of AddCommandClass

### DIFF
--- a/cpp/src/Node.cpp
+++ b/cpp/src/Node.cpp
@@ -1880,9 +1880,12 @@ void Node::ApplicationCommandHandler
 			// Dropping these messages on the floor is less than ideal. So create this command class implicitly
 			// and pass it up the stack.
 			Log::Write( LogLevel_Info, m_nodeId, "ApplicationCommandHandler - Unhandled Command Class 0x%.2x. Creating implicitly", _data[5] );
-			CommandClass* p = AddCommandClass( _data[5] );
-			p->CreateVars( 1 );
-			ApplicationCommandHandler( _data, encrypted );
+			if( CommandClass* p = AddCommandClass( _data[5] ) ) {
+				p->CreateVars(1);
+				ApplicationCommandHandler(_data, encrypted);
+			} else {
+				Log::Write( LogLevel_Info, m_nodeId, "ApplicationCommandHandler - Command Class Unknown 0x%.2x. Cannot create", _data[5] );
+			}
 		}
 	}
 }


### PR DESCRIPTION
An unknown command class may exist and will cause AddCommandClass to
return null. Handle this gracefully to avoid a crash.